### PR TITLE
API endpoint: /posts to get list of posts

### DIFF
--- a/backend/lib/backend/posts.ex
+++ b/backend/lib/backend/posts.ex
@@ -2,4 +2,15 @@ defmodule Backend.Posts do
   @moduledoc """
   The Posts context.
   """
+
+  alias Backend.Repo
+  alias Backend.Posts.Post
+
+  @doc """
+  Returns the list of posts.
+  """
+  @spec list_posts :: list()
+  def list_posts do
+    Repo.all(Post)
+  end
 end

--- a/backend/lib/backend/posts.ex
+++ b/backend/lib/backend/posts.ex
@@ -1,0 +1,5 @@
+defmodule Backend.Posts do
+  @moduledoc """
+  The Posts context.
+  """
+end

--- a/backend/lib/backend/posts.ex
+++ b/backend/lib/backend/posts.ex
@@ -3,8 +3,8 @@ defmodule Backend.Posts do
   The Posts context.
   """
 
-  alias Backend.Repo
   alias Backend.Posts.Post
+  alias Backend.Repo
 
   @doc """
   Returns the list of posts.

--- a/backend/lib/backend/posts/post.ex
+++ b/backend/lib/backend/posts/post.ex
@@ -1,4 +1,4 @@
-defmodule Backend.Post do
+defmodule Backend.Posts.Post do
   @moduledoc """
   The Post schema.
   """

--- a/backend/lib/backend_web/controllers/post_controller.ex
+++ b/backend/lib/backend_web/controllers/post_controller.ex
@@ -1,0 +1,11 @@
+defmodule BackendWeb.PostController do
+  use BackendWeb, :controller
+
+  alias Backend.Posts
+
+  def index(conn, _params) do
+    # posts = Posts.list_posts() || []
+    # Jason.encode!(posts)
+    send_resp(conn, 200, "some posts")
+  end
+end

--- a/backend/lib/backend_web/controllers/post_controller.ex
+++ b/backend/lib/backend_web/controllers/post_controller.ex
@@ -4,8 +4,20 @@ defmodule BackendWeb.PostController do
   alias Backend.Posts
 
   def index(conn, _params) do
-    # posts = Posts.list_posts() || []
-    # Jason.encode!(posts)
-    send_resp(conn, 200, "some posts")
+    posts = Posts.list_posts()
+
+    json(conn, %{
+      data:
+        for(
+          post <- posts,
+          do: %{
+            id: post.id,
+            title: post.title,
+            summary: post.summary,
+            content: post.content,
+            read_duration: post.read_duration
+          }
+        )
+    })
   end
 end

--- a/backend/lib/backend_web/router.ex
+++ b/backend/lib/backend_web/router.ex
@@ -1,11 +1,16 @@
 defmodule BackendWeb.Router do
   use BackendWeb, :router
 
+  alias PostController
+
   pipeline :api do
     plug :accepts, ["json"]
   end
 
   scope "/api", BackendWeb do
     pipe_through :api
+
+    resources "/posts", PostController, only: [:index]
+    # get "/posts", PostController, :index
   end
 end

--- a/backend/priv/repo/seeds.exs
+++ b/backend/priv/repo/seeds.exs
@@ -9,3 +9,16 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+alias Backend.Repo
+alias Backend.Posts.Post
+
+Repo.insert!(%Post{
+  title: "Hello world!",
+  content: "This is a sample post content.",
+  summary: "This is a sample post summary.",
+  read_duration: 1
+})
+
+IO.puts("")
+IO.puts("Success! Sample data has been added.")

--- a/backend/test/backend/posts_test.exs
+++ b/backend/test/backend/posts_test.exs
@@ -1,9 +1,24 @@
 defmodule Backend.PostsTest do
   use Backend.DataCase
 
+  import Backend.Factory
+
   alias Backend.Posts
 
   test "list_posts/0 returns all posts" do
-    assert [] == Posts.list_posts()
+    post =
+      insert!(:post,
+        title: "App signal implementation",
+        summary: "App signal implementation summary",
+        content: "App signal implementation content",
+        read_duration: 5
+      )
+
+    assert [post] == Posts.list_posts()
+
+    assert post.title == "App signal implementation"
+    assert post.summary == "App signal implementation summary"
+    assert post.content == "App signal implementation content"
+    assert post.read_duration == 5
   end
 end

--- a/backend/test/backend/posts_test.exs
+++ b/backend/test/backend/posts_test.exs
@@ -1,0 +1,9 @@
+defmodule Backend.PostsTest do
+  use Backend.DataCase
+
+  alias Backend.Posts
+
+  test "list_posts/0 returns all posts" do
+    assert [] == Posts.list_posts()
+  end
+end

--- a/backend/test/backend_web/controllers/post_controller_test.exs
+++ b/backend/test/backend_web/controllers/post_controller_test.exs
@@ -1,0 +1,8 @@
+defmodule BackendWeb.PostControllerTest do
+  use BackendWeb.ConnCase
+
+  test "index lists all posts", %{conn: conn} do
+    conn = get(conn, Routes.post_path(conn, :index))
+    assert true
+  end
+end

--- a/backend/test/backend_web/controllers/post_controller_test.exs
+++ b/backend/test/backend_web/controllers/post_controller_test.exs
@@ -1,8 +1,16 @@
 defmodule BackendWeb.PostControllerTest do
   use BackendWeb.ConnCase
 
+  import Backend.Factory
+
   test "index lists all posts", %{conn: conn} do
+    _post_1 = insert!(:post)
+    _post_2 = insert!(:post)
+    _post_3 = insert!(:post)
+
     conn = get(conn, Routes.post_path(conn, :index))
-    assert true
+    response = json_response(conn, 200)
+
+    assert length(response["data"]) == 3
   end
 end

--- a/backend/test/support/factory.ex
+++ b/backend/test/support/factory.ex
@@ -9,7 +9,12 @@ defmodule Backend.Factory do
   # Factories
 
   def build(:post) do
-    %Post{title: "hello world"}
+    %Post{
+      title: "hello world",
+      summary: "hello world summary",
+      content: "hello world content",
+      read_duration: 5
+    }
   end
 
   # Convenience API

--- a/backend/test/support/factory.ex
+++ b/backend/test/support/factory.ex
@@ -1,0 +1,20 @@
+defmodule Backend.Factory do
+  alias Backend.Repo
+  alias Backend.Posts.Post
+
+  # Factories
+
+  def build(:post) do
+    %Post{title: "hello world"}
+  end
+
+  # Convenience API
+
+  def build(factory_name, attributes) do
+    factory_name |> build() |> struct!(attributes)
+  end
+
+  def insert!(factory_name, attributes \\ []) do
+    factory_name |> build(attributes) |> Repo.insert!()
+  end
+end

--- a/backend/test/support/factory.ex
+++ b/backend/test/support/factory.ex
@@ -1,6 +1,10 @@
 defmodule Backend.Factory do
-  alias Backend.Repo
+  @moduledoc """
+  A factory for creating test data.
+  """
+
   alias Backend.Posts.Post
+  alias Backend.Repo
 
   # Factories
 


### PR DESCRIPTION
Closes #21 issue

### What
This PR introduces the following:
- new route for listing posts `/api/posts`
- context file which returns list of posts
- controller file for posts with index action
- tests for controller and context
- factory to generate posts in test environment
- seed file enhancement to generate local posts data